### PR TITLE
fix: add creating board in delete board test

### DIFF
--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -129,6 +129,11 @@ describe('Boards suite', () => {
       let boardId;
       // Setup
       await request
+        .post(routes.boards.create)
+        .set('Accept', 'application/json')
+        .send(TEST_BOARD_DATA);
+
+      await request
         .get(routes.boards.getAll)
         .set('Accept', 'application/json')
         .expect(200)


### PR DESCRIPTION
In case when there's no predefined board at server start
test do not create any boards to be deleted 
and in routing there's some validation like
` router.route('/:id').delete(async (req, res, next) => {`
`    try {`
`      const { params } = req;`
`      const success = await service.delete(params);`
`      if (success) {`
`        return res.status(NO_CONTENT).send();`
`      }**`
`      throw createError(NOT_FOUND, 'Item not found');`
`    } catch (error) {`
`      return next(error);`
`    }`
`  })`
test fails with 404 error