### PR TITLE
fix: add creating board in delete board test

### DIFF
--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -129,12 +129,11 @@ describe('Boards suite', () => {
       let boardId;
       // Setup
       await request
-        .get(routes.boards.getAll)
+        .post(routes.boards.create)
         .set('Accept', 'application/json')
-        .expect(200)
+        .send(TEST_BOARD_DATA)
         .then(res => {
-          jestExpect(res.body).not.toHaveLength(0);
-          boardId = res.body[0].id;
+          boardId = res.body.id;
         });
 
       // Test


### PR DESCRIPTION
In case of concurrent requests there's a case, when we get by `boardId = res.body[0].id;` board which has created by another test suite(tasks.test or users.test) and has deleted before we delete it inside boards.test suit