### PR TITLE
test: fix boards delete. delete board by id from created entity

### DIFF
--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -141,6 +141,8 @@ describe('Boards suite', () => {
         .post(routes.boards.create)
         .set('Accept', 'application/json')
         .send(TEST_BOARD_DATA)
+        .expect(200)
+        .expect('Content-Type', /json/)
         .then(res => (boardId = res.body.id));
 
       // Test

--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -14,6 +14,7 @@ const TEST_BOARD_DATA = {
 };
 describe('Boards suite', () => {
   let request = unauthorizedRequest;
+  let testBoardId;
 
   beforeAll(async () => {
     if (shouldAuthorizationBeTested) {
@@ -23,7 +24,14 @@ describe('Boards suite', () => {
     await request
       .post(routes.boards.create)
       .set('Accept', 'application/json')
-      .send(TEST_BOARD_DATA);
+      .send(TEST_BOARD_DATA)
+      .then(res => (testBoardId = res.body.id));
+  });
+
+  afterAll(async () => {
+    await request
+      .delete(routes.boards.delete(testBoardId))
+      .then(res => expect(res.status).oneOf([200, 204]));
   });
 
   describe('GET', () => {
@@ -126,16 +134,14 @@ describe('Boards suite', () => {
 
   describe('DELETE', () => {
     it('should delete board successfully', async () => {
+      // Setup:
       let boardId;
-      // Setup
+
       await request
-        .get(routes.boards.getAll)
+        .post(routes.boards.create)
         .set('Accept', 'application/json')
-        .expect(200)
-        .then(res => {
-          jestExpect(res.body).not.toHaveLength(0);
-          boardId = res.body[0].id;
-        });
+        .send(TEST_BOARD_DATA)
+        .then(res => (boardId = res.body.id));
 
       // Test
       await request


### PR DESCRIPTION
Added afterAll function that removes created board for test cases. Fixed board delete: added setup configuration for deleting board by id.