### PR TITLE
fix: [tests] get board by id bug

### DIFF
--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -50,7 +50,6 @@ describe('Boards suite', () => {
 
     it('should get a board by id', async () => {
       // Setup
-      let expectedBoard;
 
       await request
         .get(routes.boards.getAll)
@@ -58,12 +57,12 @@ describe('Boards suite', () => {
         .then(res => {
           jestExpect(Array.isArray(res.body)).toBe(true);
           jestExpect(res.body).not.toHaveLength(0);
-          expectedBoard = res.body[0];
+          jestExpect(res.body.find(e=>e.id===testBoardId)).not.toBe(-1);
         });
 
       // Test
       await request
-        .get(routes.boards.getById(expectedBoard.id))
+        .get(routes.boards.getById(testBoardId))
         .set('Accept', 'application/json')
         .expect(200)
         .expect('Content-Type', /json/)

--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -50,6 +50,7 @@ describe('Boards suite', () => {
 
     it('should get a board by id', async () => {
       // Setup
+      let expectedBoard;
 
       await request
         .get(routes.boards.getAll)
@@ -57,7 +58,8 @@ describe('Boards suite', () => {
         .then(res => {
           jestExpect(Array.isArray(res.body)).toBe(true);
           jestExpect(res.body).not.toHaveLength(0);
-          jestExpect(res.body.find(e=>e.id===testBoardId)).not.toBe(-1);
+          jestExpect(res.body.find(e => e.id === testBoardId)).not.toBe(undefined);
+          expectedBoard = res.body.find(e => e.id === testBoardId);
         });
 
       // Test


### PR DESCRIPTION
Sometimes the board test tries to get  a board id that has been already deleted in the task test. That's happened because before the board test tries to get a board by id it got board ids with "get all board" request and take first of them. The first board could be created and deleted in the tasks test.