### PR TITLE
feat: make ts compiling step running conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm ci
 
       - name: Check ESLint rules
-        run: npx eslint --no-inline-config --config ./config2021q2/.eslintrc.json --ext .js,.ts ./src
+        run: npx eslint --no-inline-config --config config2021q2/.eslintrc.json --ext .js,.ts src
 
-      - name: Check if TypeScript compiles
-        run: npx tsc --noEmit --project ./config2021q2
+      - name: Check if TypeScript files compiles (conditional)
+        run: if find src -type f -name *.ts | grep .; then npx tsc --noEmit --project config2021q2; fi


### PR DESCRIPTION
This changes the behavior of the CI workflow: run the TypeScript file compilation test only if any .ts file exist in the src folder.