### PR TITLE
chore: fix wrong name of the md5 step workflow

### DIFF
--- a/.github/workflows/md5.yml
+++ b/.github/workflows/md5.yml
@@ -17,7 +17,7 @@ jobs:
           path: config2021q2
 
       - name: Check workflows checksum
-        run: md5sum --strict --check ./config2021q2/workflows.md5
+        run: md5sum --strict --check config2021q2/workflows.md5
 
-      - name: Check src checksum
-        run: md5sum --strict --check ./config2021q2/tests.md5
+      - name: Check tests checksum
+        run: md5sum --strict --check config2021q2/tests.md5


### PR DESCRIPTION
This fixes the wrong step name of the MD5 github workflow.