### PR TITLE
test: verify response status code after delete

### DIFF
--- a/test/e2e/test/boards.test.js
+++ b/test/e2e/test/boards.test.js
@@ -93,7 +93,8 @@ describe('Boards suite', () => {
         });
 
       // Teardown
-      await request.delete(routes.boards.delete(boardId));
+      await request.delete(routes.boards.delete(boardId))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 
@@ -131,7 +132,8 @@ describe('Boards suite', () => {
         .then(res => jestExpect(res.body).toMatchObject(updatedBoard));
 
       // Teardown
-      await request.delete(routes.boards.delete(updatedBoard.id));
+      await request.delete(routes.boards.delete(updatedBoard.id))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 

--- a/test/e2e/test/tasks.test.js
+++ b/test/e2e/test/tasks.test.js
@@ -110,7 +110,8 @@ describe('Tasks suite', () => {
         });
 
       // Teardown
-      await request.delete(routes.tasks.delete(testBoardId, taskId));
+      await request.delete(routes.tasks.delete(testBoardId, taskId))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 

--- a/test/e2e/test/users.test.js
+++ b/test/e2e/test/users.test.js
@@ -68,7 +68,8 @@ describe('Users suite', () => {
       expect(userResponse.body.id).to.equal(userId);
 
       // Clean up, delete the user we created
-      await request.delete(routes.users.delete(userId));
+      await request.delete(routes.users.delete(userId))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 
@@ -93,7 +94,8 @@ describe('Users suite', () => {
         });
 
       // Teardown
-      await request.delete(routes.users.delete(userId));
+      await request.delete(routes.users.delete(userId))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 
@@ -135,7 +137,8 @@ describe('Users suite', () => {
         .then(res => jestExpect(res.body).toMatchObject(expectedUser));
 
       // Teardown
-      await request.delete(routes.users.delete(userId));
+      await request.delete(routes.users.delete(userId))
+          .then(res => expect(res.status).oneOf([200, 204]));
     });
   });
 


### PR DESCRIPTION
тесты пропускают такую ошибку, которая происходила в запросе на удаление Board в тесте "should update board successfully":

> "Internal error: update or delete on table \"board\" violates foreign key constraint \"FK_7d6b58efcc37a760ffd108eec72\" on table \"column\"

до исправления ошибки и тестов:
![Screenshot from 2022-01-16 22-37-16](https://user-images.githubusercontent.com/3858548/149679239-40c5cc17-58b4-44e0-ad4a-8a1dbadfa058.png)

после исправления тестов (т.е. после этого PR):
![Screenshot from 2022-01-16 22-19-48](https://user-images.githubusercontent.com/3858548/149679250-22624d83-d34e-4f22-895c-83287eba0c9f.png)

после исправления ошибки:
![Screenshot from 2022-01-16 22-37-16](https://user-images.githubusercontent.com/3858548/149679239-40c5cc17-58b4-44e0-ad4a-8a1dbadfa058.png)