### PR TITLE
Fix: unused import, add missed toBe, and throw error in tests if auth is not implemented

### DIFF
--- a/test/albums.e2e.spec.ts
+++ b/test/albums.e2e.spec.ts
@@ -141,7 +141,7 @@ describe('Album (e2e)', () => {
         responses.every(
           ({ statusCode }) => statusCode === StatusCodes.BAD_REQUEST,
         ),
-      );
+      ).toBe(true);
     });
   });
 

--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -6,7 +6,7 @@ import {
   shouldAuthorizationBeTested,
   removeTokenUser,
 } from './utils';
-import { artistsRoutes, albumsRoutes, tracksRoutes } from './endpoints';
+import { artistsRoutes, tracksRoutes } from './endpoints';
 
 const createArtistDto = {
   name: 'TEST_artist',

--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -134,7 +134,7 @@ describe('artist (e2e)', () => {
         responses.every(
           ({ statusCode }) => statusCode === StatusCodes.BAD_REQUEST,
         ),
-      );
+      ).toBe(true);
     });
   });
 

--- a/test/tracks.e2e.spec.ts
+++ b/test/tracks.e2e.spec.ts
@@ -138,7 +138,7 @@ describe('Tracks (e2e)', () => {
         responses.every(
           ({ statusCode }) => statusCode === StatusCodes.BAD_REQUEST,
         ),
-      );
+      ).toBe(true);
     });
   });
 

--- a/test/users.e2e.spec.ts
+++ b/test/users.e2e.spec.ts
@@ -140,7 +140,7 @@ describe('Users (e2e)', () => {
         responses.every(
           ({ statusCode }) => statusCode === StatusCodes.BAD_REQUEST,
         ),
-      );
+      ).toBe(true);
     });
   });
 

--- a/test/utils/getTokenAndUserId.ts
+++ b/test/utils/getTokenAndUserId.ts
@@ -7,20 +7,26 @@ const createUserDto = {
 
 const getTokenAndUserId = async (request) => {
   // create user
-  const response = await request
+  const {
+    body: { id: mockUserId },
+  } = await request
     .post(authRoutes.signup)
     .set('Accept', 'application/json')
     .send(createUserDto);
 
-  const mockUserId = response.body.id;
-
   // get token
-  const response2 = await request
+  const {
+    body: { accessToken },
+  } = await request
     .post(authRoutes.login)
     .set('Accept', 'application/json')
     .send(createUserDto);
 
-  const token = `Bearer ${response2.body.accessToken}`;
+  if (mockUserId === undefined || accessToken === undefined) {
+    throw new Error('Authorization is not implemented');
+  }
+
+  const token = `Bearer ${accessToken}`;
 
   return { token, mockUserId };
 };


### PR DESCRIPTION
1) refactor: delete unused import in artists test
2) missed toBe to some BAD_REQUEST tests
3) fix issue when auth tests are pass even if authentication is not implemented