### PR TITLE
feat: add artist delete test to check artistId in album of this artist

### DIFF
--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -300,5 +300,47 @@ describe('artist (e2e)', () => {
 
       expect(trackArtistId).toBeNull();
     });
+
+    it('should set album.artistId to null after deletion', async () => {
+      const creationArtistResponse = await unauthorizedRequest
+        .post(artistsRoutes.create)
+        .set(commonHeaders)
+        .send(createArtistDto);
+
+      const { id: artistId } = creationArtistResponse.body;
+
+      const createAlbumDto = {
+        name: 'TEST_album',
+        year: 2023,
+        artistId,
+      };
+
+      expect(creationArtistResponse.status).toBe(StatusCodes.CREATED);
+
+      const creationAlbumResponse = await unauthorizedRequest
+        .post(albumsRoutes.create)
+        .set(commonHeaders)
+        .send(createAlbumDto);
+
+      const { id: albumId } = creationAlbumResponse.body;
+
+      expect(creationAlbumResponse.statusCode).toBe(StatusCodes.CREATED);
+
+      const artistDeletionResponse = await unauthorizedRequest
+        .delete(artistsRoutes.delete(artistId))
+        .set(commonHeaders);
+
+      expect(artistDeletionResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+
+      const searchAlbumResponse = await unauthorizedRequest
+        .get(albumsRoutes.getById(albumId))
+        .set(commonHeaders);
+
+      expect(searchAlbumResponse.statusCode).toBe(StatusCodes.OK);
+
+      const { artistId: albumArtistId } = searchAlbumResponse.body;
+
+      expect(albumArtistId).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
I added the test because the Artist is [related to](https://github.com/rolling-scopes-school/nodejs-course-template/blob/4f45c36393f30aeb56f31a8e4a943fe6408f98b1/test/albums.e2e.spec.ts#L11) the Album. I have not found any other tests that check this relationship.
A similar test, previously deleted: https://github.com/rolling-scopes-school/nodejs-course-template/commit/78ea63aeb7010e2a3d12bf004e9df4890dbcb08e