### PR TITLE
Add tests for "/refresh" endpoint

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,6 +1,6 @@
 {
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "moduleFileExtensions": ["ts", "js"],
+  "rootDir": "test",
   "testEnvironment": "node",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest --testMatch \"<rootDir>/*.spec.ts\" --config ./test/jest-e2e.json --noStackTrace --runInBand",
-    "test:auth": "cross-env TEST_MODE=auth jest --config ./test/jest-e2e.json --noStackTrace --runInBand",
+    "test": "jest --testPathIgnorePatterns refresh.e2e.spec.ts --noStackTrace --runInBand",
+    "test:auth": "cross-env TEST_MODE=auth jest --testPathIgnorePatterns refresh.e2e.spec.ts --noStackTrace --runInBand",
+    "test:refresh": "cross-env TEST_MODE=auth jest --testPathPattern refresh.e2e.spec.ts --noStackTrace --runInBand",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
@@ -62,22 +63,5 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "test",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/test/refresh/refresh.e2e.spec.ts
+++ b/test/refresh/refresh.e2e.spec.ts
@@ -1,0 +1,115 @@
+import request from '../lib/request';
+import { authRoutes } from '../endpoints';
+import {
+  shouldAuthorizationBeTested,
+  removeTokenUser,
+  getTokenAndUserId,
+  generateRefreshToken,
+} from '../utils';
+import { HttpStatus } from '@nestjs/common';
+import { decode, JwtPayload } from 'jsonwebtoken';
+import { validate } from 'uuid';
+
+type UserTokens = {
+  userId: string;
+  login: string;
+  accessToken: string;
+  refreshToken: string;
+};
+
+type RefreshResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+interface TokenPayload extends JwtPayload {
+  userId: string;
+  login: string;
+}
+
+describe('Refresh (e2e)', () => {
+  let userTokens: UserTokens;
+  const headers = { Accept: 'application/json' };
+
+  const verifyToken = async (token: string): Promise<TokenPayload> => {
+    const payload = decode(token, { json: true });
+    if (!payload) {
+      throw new Error('Token is not valid!');
+    }
+    const { userId, login, exp } = payload as TokenPayload;
+    expect(payload).toBeInstanceOf(Object);
+    expect(login).toBeDefined();
+    expect(typeof login).toBe('string');
+    expect(userId).toBeDefined();
+    expect(typeof userId).toBe('string');
+    expect(validate(userId)).toBeTruthy();
+    expect(exp).toBeDefined();
+    expect(typeof exp).toBe('number');
+    expect(exp).toBeGreaterThan(0);
+    return payload as TokenPayload;
+  };
+
+  beforeAll(async () => {
+    if (shouldAuthorizationBeTested) {
+      const { accessToken, refreshToken, mockUserId, login, token } =
+        await getTokenAndUserId(request);
+      userTokens = { userId: mockUserId, login, accessToken, refreshToken };
+      headers['Authorization'] = token;
+    }
+  });
+
+  afterAll(async () => {
+    if (userTokens) {
+      removeTokenUser(request, userTokens.userId, headers);
+      delete headers['Authorization'];
+    }
+  });
+
+  describe('Refresh', () => {
+    it('should correctly get new tokens pair', async () => {
+      const response = await request
+        .post(authRoutes.refresh)
+        .send({ refreshToken: userTokens.refreshToken });
+
+      expect(response.statusCode).toBe(HttpStatus.OK);
+      expect(response.body).toBeInstanceOf(Object);
+
+      const { accessToken, refreshToken } = response.body as RefreshResponse;
+      expect(accessToken).toBeDefined();
+      expect(typeof accessToken).toBe('string');
+
+      expect(refreshToken).toBeDefined();
+      expect(typeof refreshToken).toBe('string');
+
+      const accessTokenPayload: TokenPayload = await verifyToken(accessToken);
+      const refreshTokenPayload: TokenPayload = await verifyToken(refreshToken);
+      expect(refreshTokenPayload.exp).toBeGreaterThan(accessTokenPayload.exp);
+    });
+
+    it('should fail with 403 (invalid refresh token)', async () => {
+      const invalidRefreshToken = Math.random().toString();
+      const response = await request
+        .post(authRoutes.refresh)
+        .send({ refreshToken: invalidRefreshToken });
+
+      expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it('should fail with 401 (no refresh token)', async () => {
+      const response = await request.post(authRoutes.refresh).send();
+      expect(response.statusCode).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should fail with 403 (expired refresh token)', async () => {
+      const payload: TokenPayload = {
+        userId: userTokens.userId,
+        login: userTokens.login,
+      };
+      const refreshToken = generateRefreshToken(payload, { expiresIn: '0s' });
+      const response = await request
+        .post(authRoutes.refresh)
+        .send({ refreshToken });
+      expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
+    });
+  });
+});

--- a/test/utils/getTokenAndUserId.ts
+++ b/test/utils/getTokenAndUserId.ts
@@ -16,7 +16,7 @@ const getTokenAndUserId = async (request) => {
 
   // get token
   const {
-    body: { accessToken },
+    body: { accessToken, refreshToken },
   } = await request
     .post(authRoutes.login)
     .set('Accept', 'application/json')
@@ -28,7 +28,13 @@ const getTokenAndUserId = async (request) => {
 
   const token = `Bearer ${accessToken}`;
 
-  return { token, mockUserId };
+  return {
+    token,
+    accessToken,
+    refreshToken,
+    mockUserId,
+    login: createUserDto.login,
+  };
 };
 
 export default getTokenAndUserId;

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,5 +1,11 @@
 import getTokenAndUserId from './getTokenAndUserId';
 import removeTokenUser from './removeTokenUser';
 import shouldAuthorizationBeTested from './shouldAuthorizationBeTested';
+import generateRefreshToken from './tokens';
 
-export { getTokenAndUserId, shouldAuthorizationBeTested, removeTokenUser };
+export {
+  getTokenAndUserId,
+  shouldAuthorizationBeTested,
+  removeTokenUser,
+  generateRefreshToken,
+};

--- a/test/utils/tokens.ts
+++ b/test/utils/tokens.ts
@@ -1,0 +1,10 @@
+import { sign, SignOptions } from 'jsonwebtoken';
+import 'dotenv/config';
+
+const refreshTokenSecurityKey = process.env.JWT_SECRET_REFRESH_KEY || '';
+
+const generateRefreshToken = (payload: any, options: SignOptions): string => {
+  return sign(payload, refreshTokenSecurityKey, options);
+};
+
+export default generateRefreshToken;


### PR DESCRIPTION
**Coverage**
Tests cover the following cases:
1. receive successful response with a new tokens pair (access/refresh tokens);
2. receive response with 401 status code in case refresh token is NOT provided in the request body;
3. receive response with 403 status code in case refresh token is provided in the request body but invalid;
4. receive response with 403 status code in case refresh token already expired.

**Implementation**

- Jest config removed from `package.json`;
- `jest.config.json` added to the project root (Jest finds it by default, no need to use `--config` CLI option anymore);
- `test/jest-e2e.json` removed as redundant.
- npm script `test:refresh` is added in order not to interfere with obligatory tests (obligatory tests are called with `--testPathIgnorePatterns refresh.e2e.spec.ts` so they do NOT include "/refresh" endpoint tests)

Resolves #79 