### PR TITLE
fix: put method in tests

### DIFF
--- a/test/albums.e2e.spec.ts
+++ b/test/albums.e2e.spec.ts
@@ -167,7 +167,7 @@ describe('Album (e2e)', () => {
       const { id: updateArtistId } = creationArtistResponse.body;
       // Preparation end
 
-      const updateResponse = await unauthorizedRequest
+      const { statusCode } = await unauthorizedRequest
         .put(albumsRoutes.update(createdId))
         .set(commonHeaders)
         .send({
@@ -176,9 +176,13 @@ describe('Album (e2e)', () => {
           artistId: updateArtistId,
         });
 
-      expect(updateResponse.statusCode).toBe(StatusCodes.OK);
+      expect(statusCode).toBe(StatusCodes.OK);
 
-      const { id: updatedId, name, year, artistId } = updateResponse.body;
+      const updatedAlbumResponse = await unauthorizedRequest
+        .get(albumsRoutes.getById(createdId))
+        .set(commonHeaders);
+
+      const { id: updatedId, name, year, artistId } = updatedAlbumResponse.body;
 
       expect(name).toBe(createAlbumDto.name);
       expect(year).toBe(updatedYear);

--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -149,7 +149,7 @@ describe('artist (e2e)', () => {
 
       expect(creationResponse.status).toBe(StatusCodes.CREATED);
 
-      const updateResponse = await unauthorizedRequest
+      const { statusCode } = await unauthorizedRequest
         .put(artistsRoutes.update(createdId))
         .set(commonHeaders)
         .send({
@@ -157,9 +157,13 @@ describe('artist (e2e)', () => {
           grammy: false,
         });
 
-      expect(updateResponse.statusCode).toBe(StatusCodes.OK);
+      expect(statusCode).toBe(StatusCodes.OK);
 
-      const { id: updatedId, name, grammy } = updateResponse.body;
+      const updatedArtistResponse = await unauthorizedRequest
+        .get(artistsRoutes.getById(createdId))
+        .set(commonHeaders);
+
+      const { id: updatedId, name, grammy } = updatedArtistResponse.body;
 
       expect(name).toBe(createArtistDto.name);
       expect(grammy).toBe(false);

--- a/test/tracks.e2e.spec.ts
+++ b/test/tracks.e2e.spec.ts
@@ -153,7 +153,7 @@ describe('Tracks (e2e)', () => {
 
       expect(creationResponse.status).toBe(StatusCodes.CREATED);
 
-      const updateResponse = await unauthorizedRequest
+      const { statusCode } = await unauthorizedRequest
         .put(tracksRoutes.update(createdId))
         .set(commonHeaders)
         .send({
@@ -163,7 +163,11 @@ describe('Tracks (e2e)', () => {
           albumId: createTrackDto.albumId,
         });
 
-      expect(updateResponse.statusCode).toBe(StatusCodes.OK);
+      expect(statusCode).toBe(StatusCodes.OK);
+
+      const updatedTrackResponse = await unauthorizedRequest
+        .get(tracksRoutes.getById(createdId))
+        .set(commonHeaders);
 
       const {
         id: updatedId,
@@ -171,7 +175,7 @@ describe('Tracks (e2e)', () => {
         duration,
         artistId,
         albumId,
-      } = updateResponse.body;
+      } = updatedTrackResponse.body;
 
       expect(name).toBe(createTrackDto.name);
       expect(artistId).toBe(createTrackDto.artistId);

--- a/test/users.e2e.spec.ts
+++ b/test/users.e2e.spec.ts
@@ -165,13 +165,17 @@ describe('Users (e2e)', () => {
 
       expect(updateResponse.statusCode).toBe(StatusCodes.OK);
 
+      const updatedUserResponse = await unauthorizedRequest
+        .get(usersRoutes.getById(createdId))
+        .set(commonHeaders);
+
       const {
         id: updatedId,
         version,
         login,
         createdAt,
         updatedAt,
-      } = updateResponse.body;
+      } = updatedUserResponse.body;
 
       expect(login).toBe(createUserDto.login);
       expect(updateResponse.body).not.toHaveProperty('password');


### PR DESCRIPTION
While checking the work of other students, I noticed that there were people who were passing their tests. But the method was not executed correctly. This concerned the PUT method. Data was sent for updates, and an object with updated fields was returned. The tests passed. But if you make a request then to the database. The object has old data. I suggest making a request for getById in tests and comparing it with this value.