### PR TITLE
fix: add headers to request

### DIFF
--- a/test/refresh/refresh.e2e.spec.ts
+++ b/test/refresh/refresh.e2e.spec.ts
@@ -69,7 +69,8 @@ describe('Refresh (e2e)', () => {
     it('should correctly get new tokens pair', async () => {
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken: userTokens.refreshToken });
+        .send({ refreshToken: userTokens.refreshToken })
+        .set(headers);
 
       expect(response.statusCode).toBe(HttpStatus.OK);
       expect(response.body).toBeInstanceOf(Object);
@@ -90,7 +91,8 @@ describe('Refresh (e2e)', () => {
       const invalidRefreshToken = Math.random().toString();
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken: invalidRefreshToken });
+        .send({ refreshToken: invalidRefreshToken })
+        .set(headers);
 
       expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
     });
@@ -108,7 +110,9 @@ describe('Refresh (e2e)', () => {
       const refreshToken = generateRefreshToken(payload, { expiresIn: '0s' });
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken });
+        .send({ refreshToken })
+        .set(headers);
+
       expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
     });
   });

--- a/test/refresh/refresh.e2e.spec.ts
+++ b/test/refresh/refresh.e2e.spec.ts
@@ -69,8 +69,8 @@ describe('Refresh (e2e)', () => {
     it('should correctly get new tokens pair', async () => {
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken: userTokens.refreshToken })
-        .set(headers);
+        .set(headers),
+        .send({ refreshToken: userTokens.refreshToken });
 
       expect(response.statusCode).toBe(HttpStatus.OK);
       expect(response.body).toBeInstanceOf(Object);
@@ -91,8 +91,8 @@ describe('Refresh (e2e)', () => {
       const invalidRefreshToken = Math.random().toString();
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken: invalidRefreshToken })
-        .set(headers);
+        .set(headers)
+        .send({ refreshToken: invalidRefreshToken });
 
       expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
     });
@@ -110,8 +110,8 @@ describe('Refresh (e2e)', () => {
       const refreshToken = generateRefreshToken(payload, { expiresIn: '0s' });
       const response = await request
         .post(authRoutes.refresh)
-        .send({ refreshToken })
-        .set(headers);
+        .set(headers)
+        .send({ refreshToken });
 
       expect(response.statusCode).toBe(HttpStatus.FORBIDDEN);
     });


### PR DESCRIPTION
in the file `refresh.e2e.spec.ts`, a `headers` object is created. Before the tests, an `Authorization` field is added to it. However, in the tests these headers were forgotten and not added to the requests. This solution should fix the issue.