### PR TITLE
fix: remove Authorization header from test

### DIFF
--- a/test/refresh/refresh.e2e.spec.ts
+++ b/test/refresh/refresh.e2e.spec.ts
@@ -29,7 +29,7 @@ interface TokenPayload extends JwtPayload {
 
 describe('Refresh (e2e)', () => {
   let userTokens: UserTokens;
-  const headers = { Accept: 'application/json' };
+  const commonHeaders = { Accept: 'application/json' };
 
   const verifyToken = async (token: string): Promise<TokenPayload> => {
     const payload = decode(token, { json: true });
@@ -51,17 +51,15 @@ describe('Refresh (e2e)', () => {
 
   beforeAll(async () => {
     if (shouldAuthorizationBeTested) {
-      const { accessToken, refreshToken, mockUserId, login, token } =
+      const { accessToken, refreshToken, mockUserId, login } =
         await getTokenAndUserId(request);
       userTokens = { userId: mockUserId, login, accessToken, refreshToken };
-      headers['Authorization'] = token;
     }
   });
 
   afterAll(async () => {
     if (userTokens) {
-      removeTokenUser(request, userTokens.userId, headers);
-      delete headers['Authorization'];
+      removeTokenUser(request, userTokens.userId, commonHeaders);
     }
   });
 


### PR DESCRIPTION
Removed the Authorization header because it’s not used in the test.
Renamed headers to commonHeaders to keep the variable name consistent across all files.

![image](https://github.com/user-attachments/assets/9b6228d8-e562-4dc1-b203-e93a270c6d2d)
